### PR TITLE
Create install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+## Aptupdater installer
+
+## CHECK ROOT (fix path to include lolcat)
+if [ "$UID" -ne "0" ]; then
+   echo -e "\nError: YOU MUST BE ROOT TO USE THIS!"
+   echo -e "Tip: Precede your command with 'sudo'\n"
+   exit 1
+fi
+
+## Fetch latest script from github & make executable
+wget -O /usr/bin/aptupdater https://raw.githubusercontent.com/Yo-kai-Sei-shin-kage/aptupdater/master/aptupdater
+chmod +x /usr/bin/aptupdater
+
+## Create logs directory
+mkdir /var/lib/aptupdater


### PR DESCRIPTION
Created a simple install script (must be run as root or with sudo). No need to chown to root because the wget command is already being run as root (or sudo). Installing is now as simple as running:

sudo bash <(curl -s https://raw.githubusercontent.com/Yo-kai-Sei-shin-kage/aptupdater/master/install.sh)
